### PR TITLE
물품수정 기능 추가

### DIFF
--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -15,10 +15,29 @@ const ProductCard = ({ product }: { product: Product }) => {
         <img
           src={product.image}
           alt={product.title}
-          className="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105"
+          className={`w-full h-full object-cover transition-transform duration-300 group-hover:scale-105 ${
+            product.saleStatus === 'SOLD_OUT' ? 'grayscale opacity-70' : ''
+          }`}
         />
+
+        {/* 예약중 / 판매완료 오버레이 */}
+        {product.saleStatus === 'RESERVED' && (
+          <div className="absolute inset-0 bg-black/40 flex items-center justify-center z-10 backdrop-blur-[1px]">
+            <span className="text-white font-bold text-lg border-2 border-white px-4 py-1.5 rounded-[4px] shadow-sm tracking-widest">
+              예약중
+            </span>
+          </div>
+        )}
+        {product.saleStatus === 'SOLD_OUT' && (
+          <div className="absolute inset-0 bg-black/60 flex items-center justify-center z-10">
+            <span className="text-gray-300 font-bold text-lg border-2 border-gray-300 px-4 py-1.5 rounded-[4px] shadow-sm tracking-widest">
+              판매완료
+            </span>
+          </div>
+        )}
+
         {product.isThunderPay && (
-          <div className="absolute bottom-2 left-2 bg-yellow-400 text-[10px] font-bold px-1 py-0.5 rounded-sm">
+          <div className="absolute bottom-2 left-2 bg-yellow-400 text-[10px] font-bold px-1 py-0.5 rounded-sm z-20">
             ⚡ 번개페이
           </div>
         )}

--- a/src/data/authhandler.ts
+++ b/src/data/authhandler.ts
@@ -25,6 +25,7 @@ export const authhandler = [
       avatar: user.avatar || '',
       shopIntro: user.shopIntro || '',
       wishList: user.wishList || [],
+      createdAt: new Date().toISOString(),
     };
 
     return HttpResponse.json({ accessToken, user: userInfo }, { status: 200 });

--- a/src/data/producthandler.ts
+++ b/src/data/producthandler.ts
@@ -1,6 +1,6 @@
 import { http, HttpResponse } from 'msw';
 import { MOCK_PRODUCTS } from './mock';
-import type { Product, CreateProductInput } from '../types/Product';
+import type { Product, CreateProductInput, SaleStatus } from '../types/Product';
 import type { Account } from '../types/Account';
 
 const getStoredProducts = (): Product[] => {
@@ -81,11 +81,30 @@ export const producthandler = [
       category: inputData.category || '기타',
       status: inputData.status || 'NEW',
       tags: inputData.tags || [],
+      saleStatus: 'ON_SALE',
     };
 
-    const updatedProducts = [newProduct, ...products];
-    localStorage.setItem('products', JSON.stringify(updatedProducts));
+    products.push(newProduct);
+    localStorage.setItem('products', JSON.stringify(products));
 
     return HttpResponse.json(newProduct, { status: 201 });
+  }),
+
+  // 4. 상품 판매 상태 변경 API
+  http.patch('/api/products/:id/status', async ({ params, request }) => {
+    const { id } = params;
+    const { saleStatus } = (await request.json()) as { saleStatus: SaleStatus };
+
+    const products = getStoredProducts();
+    const index = products.findIndex((p) => String(p.id) === String(id));
+
+    if (index === -1) {
+      return new HttpResponse(null, { status: 404 });
+    }
+
+    products[index] = { ...products[index], saleStatus };
+    localStorage.setItem('products', JSON.stringify(products));
+
+    return HttpResponse.json(products[index]);
   }),
 ];

--- a/src/data/producthandler.ts
+++ b/src/data/producthandler.ts
@@ -24,7 +24,6 @@ export const producthandler = [
     return HttpResponse.json(products);
   }),
 
-  // 2. 특정 상품 상세 조회 (조회수 중복 방지 로직 적용)
   http.get('/api/products/:id', ({ params }) => {
     const { id } = params;
     const products = getStoredProducts();
@@ -46,7 +45,6 @@ export const producthandler = [
     return HttpResponse.json(products[index]);
   }),
 
-  // 3. 상품 등록 (유저 ID 자동 주입)
   http.post('/api/products', async ({ request }) => {
     const inputData = (await request.json()) as CreateProductInput;
     const products = getStoredProducts();
@@ -90,7 +88,6 @@ export const producthandler = [
     return HttpResponse.json(newProduct, { status: 201 });
   }),
 
-  // 4. 상품 판매 상태 변경 API
   http.patch('/api/products/:id/status', async ({ params, request }) => {
     const { id } = params;
     const { saleStatus } = (await request.json()) as { saleStatus: SaleStatus };
@@ -106,5 +103,20 @@ export const producthandler = [
     localStorage.setItem('products', JSON.stringify(products));
 
     return HttpResponse.json(products[index]);
+  }),
+
+  http.delete('/api/products/:id', ({ params }) => {
+    const { id } = params;
+    const products = getStoredProducts();
+    const index = products.findIndex((p) => String(p.id) === String(id));
+
+    if (index === -1) {
+      return new HttpResponse(null, { status: 404 });
+    }
+
+    products.splice(index, 1);
+    localStorage.setItem('products', JSON.stringify(products));
+
+    return new HttpResponse(null, { status: 200 });
   }),
 ];

--- a/src/hooks/useMyPage.ts
+++ b/src/hooks/useMyPage.ts
@@ -5,7 +5,6 @@ import type { Product, SaleStatus } from '../types/Product';
 import api from '../api/axios';
 
 export const useMyPage = () => {
-  // 에러 원인 해결: 사용하지 않는 requireAuth 제거
   const { userInfo, updateUserInfo } = useAuth();
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -67,6 +66,17 @@ export const useMyPage = () => {
     }
   };
 
+  const deleteProduct = async (productId: number) => {
+    try {
+      await api.delete(`/api/products/${productId}`);
+      setMyProducts((prev) => prev.filter((p) => p.id !== productId));
+      alert('상품이 삭제되었습니다.');
+    } catch (error) {
+      console.error('상품 삭제 실패:', error);
+      alert('상품 삭제에 실패했습니다.');
+    }
+  };
+
   const getOpenDays = (joinDate: string) => {
     if (!joinDate) return 1;
     const startDate = new Date(joinDate.replace(/\./g, '-'));
@@ -123,5 +133,6 @@ export const useMyPage = () => {
     saveIntro,
     handleImageChange,
     updateProductStatus,
+    deleteProduct,
   };
 };

--- a/src/hooks/useMyPage.ts
+++ b/src/hooks/useMyPage.ts
@@ -1,13 +1,13 @@
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { VALIDATION_PATTERNS } from '../types/Account';
 import { useAuth } from './useAuth';
-import type { Product } from '../types/Product';
+import type { Product, SaleStatus } from '../types/Product';
 import api from '../api/axios';
 
 export const useMyPage = () => {
-  const { userInfo, updateUserInfo, requireAuth } = useAuth();
+  // 에러 원인 해결: 사용하지 않는 requireAuth 제거
+  const { userInfo, updateUserInfo } = useAuth();
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const isInitialRender = useRef(true);
 
   const [activeTab, setActiveTab] = useState('상품');
   const [myProducts, setMyProducts] = useState<Product[]>([]);
@@ -19,32 +19,53 @@ export const useMyPage = () => {
 
   const userId = userInfo?.id;
 
-  // 내 상품 조회 로직
-  const fetchMyProducts = useCallback(async () => {
-    if (!userId) return;
-    try {
-      const response = await api.get('/api/products');
-      const data: Product[] = Array.isArray(response.data)
-        ? response.data
-        : response.data.products || [];
-
-      const filtered = data.filter((p) => String(p.sellerId) === String(userId));
-      setMyProducts(filtered);
-    } catch (error) {
-      console.error('내 상품 로딩 실패:', error);
-    }
-  }, [userId]);
+  const sortProducts = (products: Product[]) => {
+    return [...products].sort((a, b) => {
+      if (a.saleStatus === 'SOLD_OUT' && b.saleStatus !== 'SOLD_OUT') return 1;
+      if (a.saleStatus !== 'SOLD_OUT' && b.saleStatus === 'SOLD_OUT') return -1;
+      return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+    });
+  };
 
   useEffect(() => {
-    if (isInitialRender.current) {
-      requireAuth();
-      if (userId) {
-        fetchMyProducts();
+    let ignore = false;
+
+    const fetchMyProducts = async () => {
+      if (!userId) return;
+      try {
+        const response = await api.get('/api/products');
+        const data: Product[] = Array.isArray(response.data)
+          ? response.data
+          : response.data?.products || [];
+
+        if (!ignore) {
+          const filtered = data.filter((p) => String(p.sellerId) === String(userId));
+          setMyProducts(sortProducts(filtered));
+        }
+      } catch (error) {
+        console.error('내 상품 로딩 실패:', error);
       }
-      isInitialRender.current = false;
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    };
+
+    fetchMyProducts();
+
+    return () => {
+      ignore = true;
+    };
   }, [userId]);
+
+  const updateProductStatus = async (productId: number, newStatus: SaleStatus) => {
+    try {
+      await api.patch(`/api/products/${productId}/status`, { saleStatus: newStatus });
+      setMyProducts((prev) => {
+        const updated = prev.map((p) => (p.id === productId ? { ...p, saleStatus: newStatus } : p));
+        return sortProducts(updated);
+      });
+    } catch (error) {
+      console.error('상품 상태 업데이트 실패:', error);
+      alert('상태 변경에 실패했습니다.');
+    }
+  };
 
   const getOpenDays = (joinDate: string) => {
     if (!joinDate) return 1;
@@ -101,5 +122,6 @@ export const useMyPage = () => {
     saveNickname,
     saveIntro,
     handleImageChange,
+    updateProductStatus,
   };
 };

--- a/src/pages/Mypage.tsx
+++ b/src/pages/Mypage.tsx
@@ -4,7 +4,7 @@ import { useMyPage } from '../hooks/useMyPage';
 import { Store, Users, ShoppingBag } from 'lucide-react';
 import api from '../api/axios';
 import ProductCard from '../components/ProductCard';
-import type { Product } from '../types/Product';
+import type { Product, SaleStatus } from '../types/Product';
 
 const MyPage = () => {
   const location = useLocation();
@@ -14,7 +14,7 @@ const MyPage = () => {
     userInfo,
     activeTab,
     setActiveTab,
-    myProducts, // ✅ 커스텀 훅에서 받아온 '내가 등록한 상품'
+    myProducts,
     isNicknameEditing,
     setIsNicknameEditing,
     isIntroEditing,
@@ -28,11 +28,11 @@ const MyPage = () => {
     saveNickname,
     saveIntro,
     handleImageChange,
+    updateProductStatus,
   } = useMyPage();
 
   const [wishProducts, setWishProducts] = useState<Product[]>([]);
 
-  // 찜 목록 서버 동기화 함수
   const loadWishes = useCallback(async () => {
     try {
       const savedWishesRaw = localStorage.getItem('wish_list');
@@ -44,190 +44,156 @@ const MyPage = () => {
       }
 
       const response = await api.get('/api/products');
-      const allProducts: Product[] = Array.isArray(response.data)
+      const data: Product[] = Array.isArray(response.data)
         ? response.data
         : response.data.products || [];
-
-      const filtered = allProducts.filter((p) => savedWishes.map(String).includes(String(p.id)));
-      setWishProducts(filtered);
+      const wishes = data.filter((p) => savedWishes.includes(String(p.id)));
+      setWishProducts(wishes);
     } catch (error) {
-      console.error(error);
+      console.error('찜 목록 로딩 실패:', error);
     }
   }, []);
-
-  useEffect(() => {
-    if (location.state?.activeTab) {
-      setActiveTab(location.state.activeTab);
-    }
-  }, [location.state, setActiveTab]);
 
   useEffect(() => {
     if (!hasLoaded.current) {
       loadWishes();
       hasLoaded.current = true;
     }
-
-    const handleUpdate = () => loadWishes();
-    window.addEventListener('storage-update', handleUpdate);
-    return () => window.removeEventListener('storage-update', handleUpdate);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [loadWishes]);
 
   if (!userInfo) return null;
 
   return (
-    <div className="max-w-[1024px] mx-auto py-10 px-4">
-      {/* ... (상단 프로필 영역은 디자인 유지 - 생략 없이 동일) ... */}
-      <div className="flex border border-gray-200 h-[310px] mb-12 bg-white shadow-sm">
-        <div className="w-[310px] bg-[#fafafa] flex flex-col items-center justify-center border-r border-gray-200">
-          <div
-            className="group relative w-[100px] h-[100px] bg-white rounded-full flex items-center justify-center text-5xl border border-gray-200 shadow-sm mb-4 overflow-hidden cursor-pointer"
-            onClick={() => fileInputRef.current?.click()}
-          >
-            {userInfo.avatar ? (
-              <img src={userInfo.avatar} alt="" className="w-full h-full object-cover" />
-            ) : (
-              '👤'
-            )}
-            <div className="absolute inset-0 bg-black/40 flex items-center justify-center opacity-0 group-hover:opacity-100 text-white text-xs font-bold">
-              변경
-            </div>
+    <div className="max-w-[1024px] mx-auto px-4 py-8">
+      {/* 프로필 섹션 */}
+      <div className="flex gap-8 mb-8 bg-white p-8 border border-gray-100 shadow-sm rounded-sm">
+        <div
+          className="relative group cursor-pointer w-[150px] h-[150px] flex-shrink-0"
+          onClick={() => fileInputRef.current?.click()}
+        >
+          <img
+            src={userInfo.avatar || 'https://api.dicebear.com/7.x/notionists/svg?seed=Felix'}
+            alt="프로필"
+            className="w-full h-full rounded-full object-cover border border-gray-200"
+          />
+          <div className="absolute inset-0 bg-black/40 rounded-full opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
+            <span className="text-white text-sm font-medium">사진 변경</span>
           </div>
           <input
             type="file"
             ref={fileInputRef}
+            onChange={handleImageChange}
             className="hidden"
             accept="image/*"
-            onChange={handleImageChange}
           />
-          <div className="text-center mb-6">
-            <div className="font-bold text-lg mb-1">{userInfo.nickname}</div>
-            <div className="flex justify-center text-[#ffcc00] text-sm italic">★★★★★</div>
-          </div>
-          <div className="flex gap-2 w-full px-6 text-xs">
-            <button className="flex-1 py-2 border border-gray-300 bg-white text-gray-600 font-medium hover:bg-gray-50">
-              내 상점 관리
-            </button>
-            <button className="flex-1 py-2 border border-gray-300 bg-white text-gray-600 font-medium hover:bg-gray-50">
-              번개머니
-            </button>
-          </div>
         </div>
 
-        <div className="flex-1 p-8 flex flex-col">
-          <div className="flex items-center gap-3 mb-6">
-            {isNicknameEditing ? (
-              <div className="flex items-center gap-2">
-                <input
-                  className="text-xl font-bold border-b-2 border-black outline-none pb-1"
-                  value={tempNickname}
-                  onChange={(e) => setTempNickname(e.target.value)}
-                  autoFocus
-                />
-                <button
-                  onClick={saveNickname}
-                  className="text-xs bg-black text-white px-2 py-1 rounded"
-                >
-                  확인
-                </button>
-                <button
-                  onClick={() => setIsNicknameEditing(false)}
-                  className="text-xs border px-2 py-1 rounded text-gray-400"
-                >
-                  취소
-                </button>
-              </div>
-            ) : (
-              <>
-                <h2 className="text-2xl font-bold">{userInfo.nickname}</h2>
-                <button
-                  onClick={() => setIsNicknameEditing(true)}
-                  className="px-2 py-1 text-[11px] border border-gray-200 text-gray-400 rounded hover:bg-gray-50"
-                >
-                  상점명 수정
-                </button>
-              </>
-            )}
-            <span className="ml-auto text-[11px] bg-[#ffc300] px-2 py-1 rounded-sm font-bold text-white shadow-sm">
-              ✔ 본인인증 완료
-            </span>
-          </div>
-
-          <div className="flex gap-10 text-[13px] text-gray-500 mb-6 border-t border-b border-gray-50 py-5 flex-shrink-0">
-            <div className="flex items-center gap-2">
-              <Store size={18} className="text-gray-400" strokeWidth={1.5} />
-              <span>상점오픈일</span>
-              <span className="text-gray-900 font-bold">{getOpenDays(userInfo.joinDate)}일 전</span>
-            </div>
-            <div className="flex items-center gap-2">
-              <Users size={18} className="text-gray-400" strokeWidth={1.5} />
-              <span>상점방문수</span>
-              <span className="text-gray-900 font-bold">0 명</span>
-            </div>
-            <div className="flex items-center gap-2">
-              <ShoppingBag size={18} className="text-gray-400" strokeWidth={1.5} />
-              <span>상품판매</span>
-              <span className="text-gray-900 font-bold">{myProducts.length} 회</span>
-            </div>
-          </div>
-
-          <div className="flex-1 relative overflow-hidden">
-            {isIntroEditing ? (
-              <div className="flex flex-col h-full">
-                <textarea
-                  className="w-full border p-3 text-sm outline-none resize-none flex-1 mb-1 border-gray-300 focus:border-black"
-                  value={tempIntro}
-                  onChange={(e) => setTempIntro(e.target.value.slice(0, 1000))}
-                />
-                <div className="flex justify-between items-center">
-                  <span className="text-[10px] text-gray-400">{tempIntro.length} / 1000자</span>
-                  <div className="flex gap-2">
-                    <button
-                      onClick={saveIntro}
-                      className="text-[11px] bg-gray-800 text-white px-3 py-1 rounded"
-                    >
-                      확인
-                    </button>
-                    <button
-                      onClick={() => {
-                        setIsIntroEditing(false);
-                        setTempIntro(userInfo.shopIntro || '');
-                      }}
-                      className="text-[11px] border px-3 py-1 rounded"
-                    >
-                      취소
-                    </button>
-                  </div>
-                </div>
-              </div>
-            ) : (
-              <div className="flex flex-col h-full">
-                <div className="text-sm text-gray-600 leading-relaxed pr-2 overflow-y-auto max-h-[100px] whitespace-pre-wrap">
-                  {userInfo.shopIntro || '소개글이 없습니다.'}
-                </div>
-                <div className="mt-auto pt-2">
+        <div className="flex-1">
+          <div className="flex justify-between items-start mb-4">
+            <div className="flex-1">
+              {isNicknameEditing ? (
+                <div className="flex items-center gap-2 mb-2">
+                  <input
+                    type="text"
+                    value={tempNickname}
+                    onChange={(e) => setTempNickname(e.target.value)}
+                    className="text-2xl font-bold border-b-2 border-red-500 focus:outline-none px-1"
+                  />
                   <button
-                    onClick={() => setIsIntroEditing(true)}
-                    className="text-[11px] text-gray-400 border border-gray-200 px-2 py-1 rounded hover:bg-gray-50"
+                    onClick={saveNickname}
+                    className="px-3 py-1 bg-red-500 text-white text-sm rounded"
                   >
-                    소개글 수정
+                    저장
+                  </button>
+                  <button
+                    onClick={() => setIsNicknameEditing(false)}
+                    className="px-3 py-1 bg-gray-200 text-sm rounded"
+                  >
+                    취소
                   </button>
                 </div>
+              ) : (
+                <div className="flex items-center gap-2 mb-2 group">
+                  <h1 className="text-2xl font-bold">{userInfo.nickname}</h1>
+                  <button
+                    onClick={() => setIsNicknameEditing(true)}
+                    className="text-sm border border-gray-200 px-2 py-1 rounded text-gray-500 opacity-0 group-hover:opacity-100 transition-opacity"
+                  >
+                    수정
+                  </button>
+                </div>
+              )}
+
+              <div className="flex items-center gap-4 text-sm text-gray-500 mb-4">
+                <span className="flex items-center gap-1">
+                  <Store size={16} /> 상점오픈 {getOpenDays(userInfo.createdAt || '')}일째
+                </span>
+                <span className="flex items-center gap-1">
+                  <Users size={16} /> 상점방문 0명
+                </span>
+                <span className="flex items-center gap-1">
+                  <ShoppingBag size={16} /> 상품판매 0회
+                </span>
+              </div>
+            </div>
+
+            <button className="px-4 py-2 border border-gray-300 rounded font-medium text-sm hover:bg-gray-50 transition-colors">
+              상점 공유하기
+            </button>
+          </div>
+
+          <div className="relative group">
+            {isIntroEditing ? (
+              <div className="space-y-2">
+                <textarea
+                  value={tempIntro}
+                  onChange={(e) => setTempIntro(e.target.value)}
+                  className="w-full p-3 border border-gray-200 rounded text-sm focus:outline-none focus:border-red-500 min-h-[100px] resize-none"
+                  placeholder="상점 소개글을 입력해주세요."
+                />
+                <div className="flex justify-end gap-2">
+                  <button
+                    onClick={() => setIsIntroEditing(false)}
+                    className="px-3 py-1.5 bg-gray-100 text-sm rounded"
+                  >
+                    취소
+                  </button>
+                  <button
+                    onClick={saveIntro}
+                    className="px-3 py-1.5 bg-red-500 text-white text-sm rounded"
+                  >
+                    저장
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <div
+                className="bg-gray-50 p-4 rounded text-sm text-gray-600 min-h-[100px] whitespace-pre-wrap flex justify-between items-start cursor-pointer hover:bg-gray-100 transition-colors"
+                onClick={() => setIsIntroEditing(true)}
+              >
+                <span>{userInfo.shopIntro || '상점 소개글을 입력해주세요.'}</span>
+                <span className="text-xs text-gray-400 opacity-0 group-hover:opacity-100 transition-opacity">
+                  클릭하여 수정
+                </span>
               </div>
             )}
           </div>
         </div>
       </div>
 
-      {/* ✅ 탭 메뉴에 내 상품 개수 연동 */}
-      <div className="border-t-2 border-gray-900 flex mb-8">
-        {['상품', '상점후기', '찜', '팔로잉', '팔로워'].map((tab) => (
+      <div className="flex border-b border-gray-200 mb-8">
+        {['상품', '찜', '후기'].map((tab) => (
           <button
             key={tab}
             onClick={() => setActiveTab(tab)}
-            className={`flex-1 py-4 text-[15px] font-semibold border-r border-b border-gray-200 last:border-r-0 transition-colors ${activeTab === tab ? 'bg-white border-b-white text-black' : 'bg-[#fafafa] text-gray-500 hover:text-black'}`}
+            className={`px-8 py-4 font-bold text-[15px] transition-colors relative ${
+              activeTab === tab ? 'text-gray-900' : 'text-gray-400 hover:text-gray-600'
+            }`}
           >
-            {tab}{' '}
+            {tab}
+            {activeTab === tab && (
+              <div className="absolute bottom-0 left-0 w-full h-[3px] bg-gray-900" />
+            )}
             <span className="ml-1 text-sm font-normal">
               {tab === '찜' ? wishProducts.length : tab === '상품' ? myProducts.length : '0'}
             </span>
@@ -235,7 +201,6 @@ const MyPage = () => {
         ))}
       </div>
 
-      {/* 탭 내용 리스트 */}
       <div className="min-h-[400px]">
         {activeTab === '찜' ? (
           wishProducts.length > 0 ? (
@@ -253,7 +218,18 @@ const MyPage = () => {
           myProducts.length > 0 ? (
             <div className="grid grid-cols-5 gap-4">
               {myProducts.map((product) => (
-                <ProductCard key={product.id} product={product} />
+                <div key={`manage-${product.id}`} className="flex flex-col gap-2 group">
+                  <ProductCard product={product} />
+                  <select
+                    value={product.saleStatus || 'ON_SALE'}
+                    onChange={(e) => updateProductStatus(product.id, e.target.value as SaleStatus)}
+                    className="w-full border border-gray-200 text-sm text-gray-700 py-1.5 px-2 rounded-sm focus:outline-none focus:border-red-500 transition-colors cursor-pointer"
+                  >
+                    <option value="ON_SALE">판매중</option>
+                    <option value="RESERVED">예약중</option>
+                    <option value="SOLD_OUT">판매완료</option>
+                  </select>
+                </div>
               ))}
             </div>
           ) : (
@@ -263,7 +239,7 @@ const MyPage = () => {
           )
         ) : (
           <div className="flex flex-col items-center justify-center py-32 border-b border-gray-100 text-gray-300">
-            <p className="text-sm">등록된 {activeTab}이 없습니다.</p>
+            <p className="text-sm">등록된 후기가 없습니다.</p>
           </div>
         )}
       </div>

--- a/src/pages/Mypage.tsx
+++ b/src/pages/Mypage.tsx
@@ -1,11 +1,14 @@
 import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useMyPage } from '../hooks/useMyPage';
 import { Store, Users, ShoppingBag } from 'lucide-react';
 import api from '../api/axios';
 import ProductCard from '../components/ProductCard';
 import type { Product, SaleStatus } from '../types/Product';
+import { timeAgo } from '../utils/timeAgo';
 
 const MyPage = () => {
+  const navigate = useNavigate();
   const {
     userInfo,
     activeTab,
@@ -29,7 +32,6 @@ const MyPage = () => {
 
   const [wishProducts, setWishProducts] = useState<Product[]>([]);
 
-  // 에러 원인 해결: useEffect 내부의 비동기 함수 구조 개선
   useEffect(() => {
     let ignore = false;
 
@@ -184,6 +186,7 @@ const MyPage = () => {
         </div>
       </div>
 
+      {/* 탭 네비게이션 */}
       <div className="flex border-b border-gray-200 mb-8">
         {['상품', '찜', '후기'].map((tab) => (
           <button
@@ -204,6 +207,7 @@ const MyPage = () => {
         ))}
       </div>
 
+      {/* 탭 내용 영역 */}
       <div className="min-h-[400px]">
         {activeTab === '찜' ? (
           wishProducts.length > 0 ? (
@@ -219,19 +223,92 @@ const MyPage = () => {
           )
         ) : activeTab === '상품' ? (
           myProducts.length > 0 ? (
-            <div className="grid grid-cols-5 gap-4">
+            <div className="flex flex-col border-t-2 border-black">
               {myProducts.map((product) => (
-                <div key={`manage-${product.id}`} className="flex flex-col gap-2 group">
-                  <ProductCard product={product} />
-                  <select
-                    value={product.saleStatus || 'ON_SALE'}
-                    onChange={(e) => updateProductStatus(product.id, e.target.value as SaleStatus)}
-                    className="w-full border border-gray-200 text-sm text-gray-700 py-1.5 px-2 rounded-sm focus:outline-none focus:border-red-500 transition-colors cursor-pointer"
+                <div key={`manage-${product.id}`} className="flex py-6 border-b border-gray-100">
+                  {/* 1. 이미지 및 딤 처리 영역 */}
+                  <div
+                    className="relative w-[140px] h-[140px] flex-shrink-0 border border-gray-200 cursor-pointer"
+                    onClick={() => navigate(`/product/${product.id}`)}
                   >
-                    <option value="ON_SALE">판매중</option>
-                    <option value="RESERVED">예약중</option>
-                    <option value="SOLD_OUT">판매완료</option>
-                  </select>
+                    <img
+                      src={product.image}
+                      alt={product.title}
+                      className={`w-full h-full object-cover transition-all ${
+                        product.saleStatus === 'SOLD_OUT' ? 'grayscale opacity-70' : ''
+                      }`}
+                    />
+                    {product.saleStatus === 'RESERVED' && (
+                      <div className="absolute inset-0 bg-black/40 flex items-center justify-center z-10 backdrop-blur-[1px]">
+                        <span className="text-white font-bold border-2 border-white px-3 py-1 rounded-[4px] tracking-widest text-sm">
+                          예약중
+                        </span>
+                      </div>
+                    )}
+                    {product.saleStatus === 'SOLD_OUT' && (
+                      <div className="absolute inset-0 bg-black/60 flex items-center justify-center z-10">
+                        <span className="text-gray-300 font-bold border-2 border-gray-300 px-3 py-1 rounded-[4px] tracking-widest text-sm">
+                          판매완료
+                        </span>
+                      </div>
+                    )}
+                  </div>
+
+                  {/* 2. 상품 상세 정보 영역 */}
+                  <div className="flex-1 px-6 flex flex-col justify-center">
+                    <div className="text-sm font-bold text-gray-500 mb-1">
+                      {product.saleStatus === 'ON_SALE'
+                        ? '판매중'
+                        : product.saleStatus === 'RESERVED'
+                          ? '예약중'
+                          : '판매완료'}
+                    </div>
+                    <h3
+                      className="text-lg text-gray-800 line-clamp-1 mb-2 hover:underline cursor-pointer"
+                      onClick={() => navigate(`/product/${product.id}`)}
+                    >
+                      {product.title}
+                    </h3>
+                    <div className="font-bold text-xl mb-3">{product.price.toLocaleString()}원</div>
+                    <div className="text-sm text-gray-400 flex items-center gap-2">
+                      <span>{timeAgo(product.createdAt)}</span>
+                      <span>•</span>
+                      <span className="truncate max-w-[200px]">{product.location}</span>
+                    </div>
+                  </div>
+
+                  {/* 3. 우측 컨트롤(관리) 버튼 영역 */}
+                  <div className="flex flex-col gap-2 justify-center w-[160px]">
+                    <select
+                      value={product.saleStatus || 'ON_SALE'}
+                      onChange={(e) =>
+                        updateProductStatus(product.id, e.target.value as SaleStatus)
+                      }
+                      className="w-full border border-gray-300 py-2.5 px-3 text-sm rounded-sm focus:outline-none focus:border-red-500 cursor-pointer font-medium"
+                    >
+                      <option value="ON_SALE">판매중</option>
+                      <option value="RESERVED">예약중</option>
+                      <option value="SOLD_OUT">판매완료</option>
+                    </select>
+
+                    <div className="flex gap-2">
+                      <button
+                        onClick={() => navigate(`/edit/${product.id}`)}
+                        className="flex-1 border border-gray-300 py-2.5 text-sm rounded-sm hover:bg-gray-50 font-medium transition-colors"
+                      >
+                        수정
+                      </button>
+                      <button
+                        className="flex-1 border border-gray-300 py-2.5 text-sm rounded-sm hover:bg-gray-50 font-medium transition-colors text-red-500"
+                        onClick={() => alert('삭제 기능은 준비중입니다.')}
+                      >
+                        삭제
+                      </button>
+                    </div>
+                    <button className="w-full border border-gray-300 py-2 text-sm rounded-sm hover:bg-gray-50 font-medium text-gray-600 transition-colors mt-1">
+                      UP 하기
+                    </button>
+                  </div>
                 </div>
               ))}
             </div>

--- a/src/pages/Mypage.tsx
+++ b/src/pages/Mypage.tsx
@@ -1,5 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useState, useEffect } from 'react';
 import { useMyPage } from '../hooks/useMyPage';
 import { Store, Users, ShoppingBag } from 'lucide-react';
 import api from '../api/axios';
@@ -7,9 +6,6 @@ import ProductCard from '../components/ProductCard';
 import type { Product, SaleStatus } from '../types/Product';
 
 const MyPage = () => {
-  const location = useLocation();
-  const hasLoaded = useRef(false);
-
   const {
     userInfo,
     activeTab,
@@ -33,33 +29,40 @@ const MyPage = () => {
 
   const [wishProducts, setWishProducts] = useState<Product[]>([]);
 
-  const loadWishes = useCallback(async () => {
-    try {
-      const savedWishesRaw = localStorage.getItem('wish_list');
-      const savedWishes: (number | string)[] = savedWishesRaw ? JSON.parse(savedWishesRaw) : [];
-
-      if (!Array.isArray(savedWishes) || savedWishes.length === 0) {
-        setWishProducts([]);
-        return;
-      }
-
-      const response = await api.get('/api/products');
-      const data: Product[] = Array.isArray(response.data)
-        ? response.data
-        : response.data.products || [];
-      const wishes = data.filter((p) => savedWishes.includes(String(p.id)));
-      setWishProducts(wishes);
-    } catch (error) {
-      console.error('찜 목록 로딩 실패:', error);
-    }
-  }, []);
-
+  // 에러 원인 해결: useEffect 내부의 비동기 함수 구조 개선
   useEffect(() => {
-    if (!hasLoaded.current) {
-      loadWishes();
-      hasLoaded.current = true;
-    }
-  }, [loadWishes]);
+    let ignore = false;
+
+    const loadWishes = async () => {
+      try {
+        const savedWishesRaw = localStorage.getItem('wish_list');
+        const savedWishes: (number | string)[] = savedWishesRaw ? JSON.parse(savedWishesRaw) : [];
+
+        if (!Array.isArray(savedWishes) || savedWishes.length === 0) {
+          if (!ignore) setWishProducts([]);
+          return;
+        }
+
+        const response = await api.get('/api/products');
+        const data: Product[] = Array.isArray(response.data)
+          ? response.data
+          : response.data?.products || [];
+
+        if (!ignore) {
+          const wishes = data.filter((p) => savedWishes.includes(String(p.id)));
+          setWishProducts(wishes);
+        }
+      } catch (error) {
+        console.error('찜 목록 로딩 실패:', error);
+      }
+    };
+
+    loadWishes();
+
+    return () => {
+      ignore = true;
+    };
+  }, []);
 
   if (!userInfo) return null;
 

--- a/src/pages/Mypage.tsx
+++ b/src/pages/Mypage.tsx
@@ -28,6 +28,7 @@ const MyPage = () => {
     saveIntro,
     handleImageChange,
     updateProductStatus,
+    deleteProduct,
   } = useMyPage();
 
   const [wishProducts, setWishProducts] = useState<Product[]>([]);
@@ -52,7 +53,14 @@ const MyPage = () => {
 
         if (!ignore) {
           const wishes = data.filter((p) => savedWishes.includes(String(p.id)));
-          setWishProducts(wishes);
+
+          const sortedWishes = wishes.sort((a, b) => {
+            if (a.saleStatus === 'SOLD_OUT' && b.saleStatus !== 'SOLD_OUT') return 1;
+            if (a.saleStatus !== 'SOLD_OUT' && b.saleStatus === 'SOLD_OUT') return -1;
+            return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+          });
+
+          setWishProducts(sortedWishes);
         }
       } catch (error) {
         console.error('찜 목록 로딩 실패:', error);
@@ -65,6 +73,12 @@ const MyPage = () => {
       ignore = true;
     };
   }, []);
+
+  const handleDeleteClick = (productId: number) => {
+    if (window.confirm('정말로 이 상품을 삭제하시겠습니까?\n삭제된 데이터는 복구할 수 없습니다.')) {
+      deleteProduct(productId);
+    }
+  };
 
   if (!userInfo) return null;
 
@@ -186,7 +200,6 @@ const MyPage = () => {
         </div>
       </div>
 
-      {/* 탭 네비게이션 */}
       <div className="flex border-b border-gray-200 mb-8">
         {['상품', '찜', '후기'].map((tab) => (
           <button
@@ -207,7 +220,6 @@ const MyPage = () => {
         ))}
       </div>
 
-      {/* 탭 내용 영역 */}
       <div className="min-h-[400px]">
         {activeTab === '찜' ? (
           wishProducts.length > 0 ? (
@@ -226,7 +238,6 @@ const MyPage = () => {
             <div className="flex flex-col border-t-2 border-black">
               {myProducts.map((product) => (
                 <div key={`manage-${product.id}`} className="flex py-6 border-b border-gray-100">
-                  {/* 1. 이미지 및 딤 처리 영역 */}
                   <div
                     className="relative w-[140px] h-[140px] flex-shrink-0 border border-gray-200 cursor-pointer"
                     onClick={() => navigate(`/product/${product.id}`)}
@@ -254,7 +265,6 @@ const MyPage = () => {
                     )}
                   </div>
 
-                  {/* 2. 상품 상세 정보 영역 */}
                   <div className="flex-1 px-6 flex flex-col justify-center">
                     <div className="text-sm font-bold text-gray-500 mb-1">
                       {product.saleStatus === 'ON_SALE'
@@ -277,7 +287,6 @@ const MyPage = () => {
                     </div>
                   </div>
 
-                  {/* 3. 우측 컨트롤(관리) 버튼 영역 */}
                   <div className="flex flex-col gap-2 justify-center w-[160px]">
                     <select
                       value={product.saleStatus || 'ON_SALE'}
@@ -299,8 +308,8 @@ const MyPage = () => {
                         수정
                       </button>
                       <button
+                        onClick={() => handleDeleteClick(product.id)}
                         className="flex-1 border border-gray-300 py-2.5 text-sm rounded-sm hover:bg-gray-50 font-medium transition-colors text-red-500"
-                        onClick={() => alert('삭제 기능은 준비중입니다.')}
                       >
                         삭제
                       </button>

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -19,7 +19,15 @@ const Home = () => {
         const data: Product[] =
           (Array.isArray(response.data) ? response.data : response.data?.products) || [];
 
-        setProducts(data);
+        const onSaleProducts = data.filter(
+          (product) => !product.saleStatus || product.saleStatus === 'ON_SALE',
+        );
+
+        const sortedProducts = onSaleProducts.sort(
+          (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+        );
+
+        setProducts(sortedProducts);
       } catch (error) {
         console.error('상품 로딩 실패:', error);
       }
@@ -49,11 +57,9 @@ const Home = () => {
         </section>
 
         <h2 className="text-xl font-bold mb-6">오늘의 상품 추천</h2>
-
-        {/* 상품 그리드 레이아웃 */}
         <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-y-10 gap-x-4">
           {products.map((product) => (
-            <ProductCard key={`homeProduct${product.id}`} product={product} />
+            <ProductCard key={product.id} product={product} />
           ))}
         </div>
       </main>

--- a/src/types/Account.ts
+++ b/src/types/Account.ts
@@ -9,6 +9,7 @@ export interface Account {
   nickname: string;
   shopIntro?: string;
   wishList: string;
+  createdAt: string;
 }
 
 export type SignupData = Omit<Account, 'id' | 'joinDate'> & { password: string };

--- a/src/types/Product.ts
+++ b/src/types/Product.ts
@@ -1,3 +1,5 @@
+export type SaleStatus = 'ON_SALE' | 'RESERVED' | 'SOLD_OUT';
+
 export interface Product {
   id: number;
   sellerId: string;
@@ -14,6 +16,7 @@ export interface Product {
   category: string; // 카테고리
   status: string; // 상품 상태 코드
   tags: string[]; // 태그 리스트
+  saleStatus?: SaleStatus; // 판매상태
 }
 
 export interface CreateProductInput extends Omit<


### PR DESCRIPTION
## 📝 작업 내용 (Description)

본인이 올린 물품을 내 상점에서 삭제 가능합니다.

## ✨ 변경 사항 (Changes)
Mypage Ui를 작업에 용이하게 변경하였습니다.
비동기처리를 적용하여 코드를 보완하였습니다.
예약중과 판매완료된 상품은 이미지 채도와 텍스트로 표시됩니다.
예약중과 판매완료된 상품은 일괄 판매중인 상품보다 리스트 우선순위가 낮습니다.
이제 `timeago`로직이 물품에서 작동합니다.
'판매중'과 '판매완료'된 상품은 `home`인 '상품추천'에 뜨지않습니다.

## 📸 스크린샷 (Screenshots)

<img width="636" height="660" alt="image" src="https://github.com/user-attachments/assets/82e808ef-cb49-4c61-8d44-7f8a5b3417f3" />
<img width="706" height="682" alt="image" src="https://github.com/user-attachments/assets/20938b4c-409d-47f0-8c01-4f00e28f5ba9" />
<img width="656" height="663" alt="image" src="https://github.com/user-attachments/assets/95fb6783-f802-4e54-ba74-5c642ea57448" />


## ✅ 리뷰어 체크리스트 (Reviewer Checklist)

- [ ] 코드가 문제없이 빌드되고 실행되는가?
- [ ] 코드 스타일 컨벤션을 준수하는가?
- [ ] 불필요한 로그나 주석이 없는가?
- [ ] 관련 문서(README 등)가 업데이트되었는가?

## 📢 참고 사항 (Notes)

시간여유상 구현 가능한 모든 기능 구현 후 일괄 코드 리팩토링을 적용할 예정입니다.
아직 수정페이지는 미구현되어있습니다. 다음 이슈로 작업 예정입니다.

## 🧐 이슈 (Related Issues)

- Closes #61
